### PR TITLE
Endring av ports og oidc-provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Docker-compose-oppsett for DittNAV
 Docker-compose-fil som kan brukes for å starte alle DittNAV sine avhengigheter lokalt.
 
+OBS per nå må vi autentisere oss mot githubs package registry for å hente stub-oidc-provider, dette gjør man ved:
+`docker login docker.pkg.github.com -u USERNAME -p TOKEN`
+
+Brukernavn og token tilhører githubkontoen din (der tokenet må ha tilgang til read fra package registry)
+
 # Kom i gang
 
 # Henvendelser

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,7 @@ services:
       localhost.no:
         aliases:
           - aggregator.localhost.no
-    image: "navikt/dittnav-event-aggregator:04325f31dff0076d87c6368e5bca58cd8a14e740"
+    image: "navikt/dittnav-event-aggregator:5494f9a3086e92a1a52aeac4de4a9cfab593c571"
     ports:
       - "8093:8080"
     environment:
@@ -118,7 +118,7 @@ services:
       localhost.no:
         aliases:
           - handler.localhost.no
-    image: "navikt/dittnav-event-handler:c3f7ba6fee9fef68f96307bbe81c7d4e4a17fe44"
+    image: "navikt/dittnav-event-handler:a1c971abcc36a9dcf96adce8ccc2971b7e7a3c39"
     ports:
       - "8092:8080"
     environment:
@@ -142,7 +142,7 @@ services:
       localhost.no:
         aliases:
           - api.localhost.no
-    image: "navikt/dittnav-api:09097367f4425c53a17640675cf1cff477f63001"
+    image: "navikt/dittnav-api:96f043e49f9c61093d8cd36c021bcf498a659807"
     ports:
       - "8091:8080"
     environment:
@@ -159,7 +159,7 @@ services:
       localhost.no:
         aliases:
           - producer.localhost.no
-    image: "navikt/dittnav-event-test-producer:0.8.0"
+    image: "navikt/dittnav-event-test-producer@sha256:03fd4ccd6d973f47badd443d7446ac9d14553275657eb41035aecb56979684e2"
     ports:
       - "8094:8080"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,9 +74,13 @@ services:
       localhost.no:
         aliases:
           - oidc-provider.localhost.no
-    image: "navikt/stub-oidc-provider:33"
+    image: "docker.pkg.github.com/navikt/stub-oidc-provider/stub-oidc-provider:latest"
     ports:
-      - "8080:8080"
+      - "9000:9000"
+    environment:
+      PORT: "9000"
+      CALLBACK_URL: "http://localhost:5000/callback"
+      ISSUER: "https://localhost:9000"
 
   oidc-provider-gui:
     container_name: oidc-provider-gui
@@ -86,7 +90,7 @@ services:
           - oidc-provider-gui.localhost.no
     image: "navikt/pb-oidc-provider-gui:0.9.0"
     ports:
-      - "7000:7000"
+      - "5000:5000"
     depends_on:
       - oidc-provider
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,7 +142,7 @@ services:
       localhost.no:
         aliases:
           - api.localhost.no
-    image: "navikt/dittnav-api:96f043e49f9c61093d8cd36c021bcf498a659807"
+    image: "navikt/dittnav-api:db357bd4c8e3f73296656fa2a1acd2a4718010f0"
     ports:
       - "8091:8080"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,9 +74,9 @@ services:
       localhost.no:
         aliases:
           - oidc-provider.localhost.no
-    image: "navikt/pb-oidc-provider:0.5.0"
+    image: "navikt/stub-oidc-provider:33"
     ports:
-      - "9000:9000"
+      - "8080:8080"
 
   oidc-provider-gui:
     container_name: oidc-provider-gui
@@ -84,9 +84,9 @@ services:
       localhost.no:
         aliases:
           - oidc-provider-gui.localhost.no
-    image: "navikt/pb-oidc-provider-gui:0.8.0"
+    image: "navikt/pb-oidc-provider-gui:0.9.0"
     ports:
-      - "5000:5000"
+      - "7000:7000"
     depends_on:
       - oidc-provider
 


### PR DESCRIPTION
Fra Sissel:
Det er et lite men her: det er at stub-oidc-provider gir CORS-feil, slik at man må aktivt ignorere CORS-feil i browseren for å få dette til å kjøre. Annet enn det har jeg testet at med oppdatert event-handler og test-producer får jeg kjørt gjennom et event for en bruker.

Tenker det burde gå fint å få fiksa den CORS-saken, selv om jeg ikke har satt meg fullstendig inn i det enda.