### PR TITLE
Legger til et enkelt image for å populere databasen med data nødvendig for oppstart i docker-compose.

### DIFF
--- a/.github/workflows/on-push-to-master.yml
+++ b/.github/workflows/on-push-to-master.yml
@@ -1,0 +1,22 @@
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - db-datapopulator/**
+
+env:
+  IMAGE: docker.pkg.github.com/${{ github.repository }}/db-datapopulator
+  VERSION: latest
+
+jobs:
+  build-and-publish-on-master:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Bygg, tag og push Docker image
+        run: |
+          docker build -t ${IMAGE}:${VERSION} db-datapopulator/.
+          docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p ${{ secrets.GITHUB_TOKEN }}
+          docker push ${IMAGE}

--- a/db-datapopulator/Dockerfile
+++ b/db-datapopulator/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine
+
+COPY entrypoint.sh /entrypoint.sh
+COPY testdata.sql /testdata.sql
+
+RUN apk add --no-cache postgresql-client
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/db-datapopulator/entrypoint.sh
+++ b/db-datapopulator/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+DB_USER="${DB_NAME}-user"
+psql postgresql://$DB_USER:$DB_PASSWORD@$DB_HOST/$DB_NAME -f ./testdata.sql;

--- a/db-datapopulator/testdata.sql
+++ b/db-datapopulator/testdata.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS systembrukere (
+    systembruker character varying(50) not null primary key,
+    produsentnavn character varying(100) not null
+);
+
+INSERT INTO systembrukere(systembruker, produsentnavn) VALUES ('dittnav', 'dittnav') ON CONFLICT DO NOTHING;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,17 @@ services:
       POSTGRES_PASSWORD: "testpassword"
       POSTGRES_DB: "dittnav-event-cache-preprod"
 
+  db-datapopulator:
+    container_name: db-datapopulator
+    networks:
+      dittnav.docker-internal:
+        aliases:
+          - db-datapopulator.dittnav.docker-internal
+    image: docker.pkg.github.com/navikt/dittnav-docker-compose/db-datapopulator:latest
+    env_file: .env
+    depends_on:
+      - aggregator
+
   zookeeper:
     container_name: zookeeper
     networks:


### PR DESCRIPTION
Mer spesifikt gjelder dette p.t. kun mapping mellom systembruker og produsentnavn. 

Bygger docker-container tagget med latest ved push til master ved commits på filer inkludert i denne imaget.