### PR TITLE
Skal ikke feile ved ukjente properties

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/e2e/client/JsonConfig.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/e2e/client/JsonConfig.kt
@@ -1,9 +1,11 @@
 package no.nav.personbruker.dittnav.e2e.client
 
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import io.ktor.client.features.json.JacksonSerializer
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.ktor.client.features.json.*
 
 fun buildJsonSerializer(): JacksonSerializer {
     return JacksonSerializer {
@@ -13,5 +15,7 @@ fun buildJsonSerializer(): JacksonSerializer {
 
 fun ObjectMapper.enableDittNavJsonConfig() {
     registerModule(JavaTimeModule())
+    registerKotlinModule()
     disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
 }


### PR DESCRIPTION
Justert Jackson-oppsettet slik at testene ikke skal feile hvis det mottas properties som DTO-en ikke kjenner til.

PB-490. Gjort det mulig å hente varsler samtidig som beskjeder i dev