### PR TITLE
Oppdaterer testcontainers til en rc-versjon, pga. kompatibilitet med Docker 2.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-val testContainersVersion = "1.14.1"
+val testContainersVersion = "1.15.0-rc2"
 
 plugins {
     kotlin("jvm") version "1.3.72"


### PR DESCRIPTION
Testcontainers ville ikke starte etter oppgradering til Docker 2.4 lokalt. Det fungerer med denne rc-versjonen. Fint om andre også kan verifisere det. 