### PR TITLE
Legger til nye miljøvariabler

### DIFF
--- a/.env
+++ b/.env
@@ -11,6 +11,8 @@ DB_PASSWORD=testpassword
 DB_MOUNT_PATH=notUsedOnLocalhost
 
 OIDC_DISCOVERY_URL=http://oidc-provider.dittnav.docker-internal:9000/.well-known/openid-configuration
+LOGINSERVICE_IDPORTEN_DISCOVERY_URL=http://oidc-provider.dittnav.docker-internal:9000/.well-known/openid-configuration
 OIDC_ISSUER=https://localhost:9000
 OIDC_ACCEPTED_AUDIENCE=stubOidcClient
+LOGINSERVICE_IDPORTEN_AUDIENCE=stubOidcClient
 OIDC_CLAIM_CONTAINING_THE_IDENTITY=pid


### PR DESCRIPTION
Legger til nye miljøvariabler for discoveryurl og audience for alle apper som bruker .env.

Foreløpig lar vi de gamle være, inntil alle apper ikke lengre er avhengig av de. Etter det tenker jeg å fjerne de.