### PR TITLE
La til miljøvariabel for innloggingsstatus

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -335,6 +335,7 @@ services:
       LOGIN_URL: "http://localhost:5000?redirect=http://localhost:3000"
       VTA_URL: "http://dummyVeientilarbeid.nav.no"
       INNLOGGINGSLINJE_API_URL: "http://localhost:8095/innloggingslinje-api"
+      INNLOGGINGSSTATUS_URL: "http://localhost:8095/innloggingslinje-api"
       ARBEIDSSOKERREGISTRERING_URL: "http://dummyArbeidssokerregistrering.nav.no"
       TEST_SIDE_FEATURE_TOGGLE: "true"
       AKTIVITETSPLAN_URL: "http://dummyAktivitetsplan.nav.no"


### PR DESCRIPTION
La til miljøvariabel for innloggingsstatus. Fjerner `INNLOGGINGSLINJE_API_URL` når PB-566 er ute i produksjon.