### PR TITLE
Bruker wget istedenfor curl for helsesjekk

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,10 +36,10 @@ dependencies {
 
 tasks {
     compileKotlin {
-        kotlinOptions.jvmTarget = "1.8"
+        kotlinOptions.jvmTarget = "13"
     }
     compileTestKotlin {
-        kotlinOptions.jvmTarget = "1.8"
+        kotlinOptions.jvmTarget = "13"
     }
 
     withType<Test> {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,7 +153,7 @@ services:
       - postgres-event-cache
       - oidc-provider-gui
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8080/internal/isAlive"]
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 http://localhost:8080/internal/isAlive"]
       interval: 2s
       timeout: 2s
       retries: 10

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Curl er ikke lengre tilgjengelig gjennom baseimaget, bruker derfor wget istedenfor slik at helsesjekken for aggregator fortsatt kan brukes.