### PR TITLE
Bytter token, da eksisterende er deprecated

### DIFF
--- a/.github/workflows/on-dispatch-run-test.yml
+++ b/.github/workflows/on-dispatch-run-test.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_PUSH_USERNAME }}
-          password: ${{ secrets.GHCR_PUSH_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.READ_PACKAGES_PAT }}
       - name: Docker pull
         run: docker-compose pull
       - name: Run end-to-end-tests

--- a/.github/workflows/on-push-to-master.yml
+++ b/.github/workflows/on-push-to-master.yml
@@ -20,8 +20,8 @@ jobs:
       - uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_PUSH_USERNAME }}
-          password: ${{ secrets.GHCR_PUSH_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Bygg, tag og push Docker image
         run: |
           docker build -t ${IMAGE}:${VERSION} db-datapopulator/.


### PR DESCRIPTION
Snappet opp en Slack-tråd der det står at GHCR_PUSH_TOKEN skal fases ut. Erstattet med READ_PACKAGES_PAT, som nå er anbefalt å bruke: https://nav-it.slack.com/archives/C60FFACN5/p1630092343016100?thread_ts=1630071164.010400&cid=C60FFACN5