### PR TITLE
PB-853. Printing av logger for relevante containere i e2e

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     testImplementation(Junit.api)
     testImplementation(Junit.params)
     testImplementation(Kluent.kluent)
+    testImplementation(Mockk.mockk)
     testImplementation(TestContainers.junitJupiter)
     testImplementation(TestContainers.testContainers) {
         exclude("junit", "junit")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ tasks {
     withType<Test> {
         useJUnitPlatform()
         testLogging {
+            showStandardStreams = true
             exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
             events("passed", "skipped", "failed")
         }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/beskjed/BeskjedIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/beskjed/BeskjedIT.kt
@@ -5,6 +5,9 @@ import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
 import no.nav.personbruker.dittnav.e2e.config.UsesTheCommonDockerComposeContext
+import no.nav.personbruker.dittnav.e2e.debugging.ApiContainerLogs
+import no.nav.personbruker.dittnav.e2e.debugging.MocksContainerLogs
+import no.nav.personbruker.dittnav.e2e.debugging.ProducerContainerLogs
 import no.nav.personbruker.dittnav.e2e.doknotifikasjon.DoknotifikasjonDTO
 import no.nav.personbruker.dittnav.e2e.done.ProduceDoneDTO
 import no.nav.personbruker.dittnav.e2e.operations.ApiOperations
@@ -14,7 +17,13 @@ import no.nav.personbruker.dittnav.e2e.security.TokenInfo
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should contain all`
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 
+@ExtendWith(
+    MocksContainerLogs::class,
+    ApiContainerLogs::class,
+    ProducerContainerLogs::class
+)
 internal class BeskjedIT : UsesTheCommonDockerComposeContext() {
 
     private val ident = "12345678901"
@@ -80,8 +89,8 @@ internal class BeskjedIT : UsesTheCommonDockerComposeContext() {
         }
 
         val doknotifikasjonerToMatch = listOf(
-                DoknotifikasjonDTO("B-username-${activeBeskjed!![0].eventId}"),
-                DoknotifikasjonDTO("B-username-${activeBeskjed[1].eventId}")
+            DoknotifikasjonDTO("B-username-${activeBeskjed!![0].eventId}"),
+            DoknotifikasjonDTO("B-username-${activeBeskjed[1].eventId}")
         )
 
         val doknotifikasjoner = `wait for values to be returned`(doknotifikasjonerToMatch) {
@@ -100,7 +109,12 @@ internal class BeskjedIT : UsesTheCommonDockerComposeContext() {
 
     private fun `produce beskjed at level`(originalBeskjed: ProduceBeskjedDTO, token: TokenInfo) {
         runBlocking {
-            client.post<HttpResponse>(ServiceConfiguration.PRODUCER, ProducerOperations.PRODUCE_BESKJED, originalBeskjed, token)
+            client.post<HttpResponse>(
+                ServiceConfiguration.PRODUCER,
+                ProducerOperations.PRODUCE_BESKJED,
+                originalBeskjed,
+                token
+            )
         }.status `should be equal to` HttpStatusCode.OK
     }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/AggregatorContainerLogs.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/AggregatorContainerLogs.kt
@@ -1,0 +1,8 @@
+package no.nav.personbruker.dittnav.e2e.debugging
+
+import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
+
+class AggregatorContainerLogs : PrintContainerLogsOnErrors {
+    override val faildTests: MutableList<String> = mutableListOf()
+    override val service = ServiceConfiguration.AGGREGATOR
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/ApiContainerLogs.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/ApiContainerLogs.kt
@@ -1,0 +1,8 @@
+package no.nav.personbruker.dittnav.e2e.debugging
+
+import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
+
+class ApiContainerLogs : PrintContainerLogsOnErrors {
+    override val faildTests: MutableList<String> = mutableListOf()
+    override val service = ServiceConfiguration.API
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/BrukernotifikasjonbestillerContainerLogs.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/BrukernotifikasjonbestillerContainerLogs.kt
@@ -1,0 +1,8 @@
+package no.nav.personbruker.dittnav.e2e.debugging
+
+import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
+
+class BrukernotifikasjonbestillerContainerLogs : PrintContainerLogsOnErrors {
+    override val faildTests: MutableList<String> = mutableListOf()
+    override val service = ServiceConfiguration.BRUKERNOTIFIKASJONBESTILLER
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/DekoratorenContainerLogs.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/DekoratorenContainerLogs.kt
@@ -1,0 +1,8 @@
+package no.nav.personbruker.dittnav.e2e.debugging
+
+import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
+
+class DekoratorenContainerLogs : PrintContainerLogsOnErrors {
+    override val faildTests: MutableList<String> = mutableListOf()
+    override val service = ServiceConfiguration.DEKORATOREN
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/FrontendContainerLogs.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/FrontendContainerLogs.kt
@@ -1,0 +1,8 @@
+package no.nav.personbruker.dittnav.e2e.debugging
+
+import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
+
+class FrontendContainerLogs : PrintContainerLogsOnErrors {
+    override val faildTests: MutableList<String> = mutableListOf()
+    override val service = ServiceConfiguration.FRONTEND
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/HandlerContainerLogs.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/HandlerContainerLogs.kt
@@ -1,0 +1,8 @@
+package no.nav.personbruker.dittnav.e2e.debugging
+
+import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
+
+class HandlerContainerLogs : PrintContainerLogsOnErrors {
+    override val faildTests: MutableList<String> = mutableListOf()
+    override val service = ServiceConfiguration.HANDLER
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/LegacyContainerLogs.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/LegacyContainerLogs.kt
@@ -1,0 +1,8 @@
+package no.nav.personbruker.dittnav.e2e.debugging
+
+import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
+
+class LegacyContainerLogs : PrintContainerLogsOnErrors {
+    override val faildTests: MutableList<String> = mutableListOf()
+    override val service = ServiceConfiguration.LEGACY
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/MocksContainerLogs.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/MocksContainerLogs.kt
@@ -1,0 +1,8 @@
+package no.nav.personbruker.dittnav.e2e.debugging
+
+import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
+
+class MocksContainerLogs : PrintContainerLogsOnErrors {
+    override val faildTests: MutableList<String> = mutableListOf()
+    override val service = ServiceConfiguration.MOCKS
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/OidcProviderContainerLogs.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/OidcProviderContainerLogs.kt
@@ -1,0 +1,8 @@
+package no.nav.personbruker.dittnav.e2e.debugging
+
+import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
+
+class OidcProviderContainerLogs : PrintContainerLogsOnErrors {
+    override val faildTests: MutableList<String> = mutableListOf()
+    override val service = ServiceConfiguration.OIDC_PROVIDER
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/OidcProviderGuiContainerLogs.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/OidcProviderGuiContainerLogs.kt
@@ -1,0 +1,8 @@
+package no.nav.personbruker.dittnav.e2e.debugging
+
+import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
+
+class OidcProviderGuiContainerLogs : PrintContainerLogsOnErrors {
+    override val faildTests: MutableList<String> = mutableListOf()
+    override val service = ServiceConfiguration.OIDC_PROVIDER_GUI
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/PrintContainerLogsOnErrors.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/PrintContainerLogsOnErrors.kt
@@ -32,15 +32,20 @@ interface PrintContainerLogsOnErrors : TestWatcher, AfterAllCallback {
 
     override fun afterAll(context: ExtensionContext?) {
         if (faildTests.isNotEmpty()) {
+            val logPrefix = "${service.name}: "
+            val containerLogs = dockerComposeContext.getLogsFor(service)
+            val containerLogsWithPrefix = containerLogs.replace("\n", "\n$logPrefix")
+
+            log.info("------------------------------------------------------------------------------------------------")
             log.info("Følgende tester feilet:")
             faildTests.forEach { fT ->
                 log.info("* $fT")
             }
+
             log.info("Relevante logger")
-            log.info("----------------------------------------------------------------------------------------------")
             log.info("Container logger for $service")
-            log.info(dockerComposeContext.getLogsFor(service))
-            log.info("----------------------------------------------------------------------------------------------")
+            log.info("\n${logPrefix}${containerLogsWithPrefix}")
+            log.info("------------------------------------------------------------------------------------------------")
         }
     }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/PrintContainerLogsOnErrors.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/PrintContainerLogsOnErrors.kt
@@ -1,0 +1,47 @@
+package no.nav.personbruker.dittnav.e2e.debugging
+
+import no.nav.personbruker.dittnav.e2e.config.DittNavDockerComposeCommonContext
+import no.nav.personbruker.dittnav.e2e.config.DittNavDockerComposeContainer
+import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.TestWatcher
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+interface PrintContainerLogsOnErrors : TestWatcher, AfterAllCallback {
+
+    private val log: Logger
+        get() = LoggerFactory.getLogger(this.javaClass.name)
+
+    private val dockerComposeContext: DittNavDockerComposeContainer
+        get() = DittNavDockerComposeCommonContext.instance
+    val faildTests: MutableList<String>
+
+    val service: ServiceConfiguration
+
+    override fun testAborted(context: ExtensionContext?, cause: Throwable?) {
+        val testName = context?.displayName ?: "No name specified"
+        faildTests.add(testName)
+    }
+
+    override fun testFailed(context: ExtensionContext?, e: Throwable?) {
+        val testName = context?.displayName ?: "No name specified"
+        faildTests.add(testName)
+    }
+
+    override fun afterAll(context: ExtensionContext?) {
+        if (faildTests.isNotEmpty()) {
+            log.debug("Følgende tester feilet:")
+            faildTests.forEach { fT ->
+                log.debug("* $fT")
+            }
+            log.debug("Relevante logger")
+            log.debug("----------------------------------------------------------------------------------------------")
+            log.debug("Container logger for $service")
+            log.debug(dockerComposeContext.getLogsFor(service))
+            log.debug("----------------------------------------------------------------------------------------------")
+        }
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/PrintContainerLogsOnErrors.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/PrintContainerLogsOnErrors.kt
@@ -32,15 +32,15 @@ interface PrintContainerLogsOnErrors : TestWatcher, AfterAllCallback {
 
     override fun afterAll(context: ExtensionContext?) {
         if (faildTests.isNotEmpty()) {
-            log.debug("Følgende tester feilet:")
+            log.info("Følgende tester feilet:")
             faildTests.forEach { fT ->
-                log.debug("* $fT")
+                log.info("* $fT")
             }
-            log.debug("Relevante logger")
-            log.debug("----------------------------------------------------------------------------------------------")
-            log.debug("Container logger for $service")
-            log.debug(dockerComposeContext.getLogsFor(service))
-            log.debug("----------------------------------------------------------------------------------------------")
+            log.info("Relevante logger")
+            log.info("----------------------------------------------------------------------------------------------")
+            log.info("Container logger for $service")
+            log.info(dockerComposeContext.getLogsFor(service))
+            log.info("----------------------------------------------------------------------------------------------")
         }
     }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/ProducerContainerLogs.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/ProducerContainerLogs.kt
@@ -1,0 +1,8 @@
+package no.nav.personbruker.dittnav.e2e.debugging
+
+import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
+
+class ProducerContainerLogs : PrintContainerLogsOnErrors {
+    override val faildTests: MutableList<String> = mutableListOf()
+    override val service = ServiceConfiguration.PRODUCER
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/TidslinjeContainerLogs.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/TidslinjeContainerLogs.kt
@@ -1,0 +1,8 @@
+package no.nav.personbruker.dittnav.e2e.debugging
+
+import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
+
+class TidslinjeContainerLogs : PrintContainerLogsOnErrors {
+    override val faildTests: MutableList<String> = mutableListOf()
+    override val service = ServiceConfiguration.TIDSLINJE
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/VarselbestillerContainerLogs.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/VarselbestillerContainerLogs.kt
@@ -1,0 +1,8 @@
+package no.nav.personbruker.dittnav.e2e.debugging
+
+import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
+
+class VarselbestillerContainerLogs : PrintContainerLogsOnErrors {
+    override val faildTests: MutableList<String> = mutableListOf()
+    override val service = ServiceConfiguration.VARSELBESTILLER
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/done/DoneIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/done/DoneIT.kt
@@ -7,6 +7,9 @@ import no.nav.personbruker.dittnav.e2e.beskjed.ProduceBeskjedDTO
 import no.nav.personbruker.dittnav.e2e.client.BrukernotifikasjonDTO
 import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
 import no.nav.personbruker.dittnav.e2e.config.UsesTheCommonDockerComposeContext
+import no.nav.personbruker.dittnav.e2e.debugging.ApiContainerLogs
+import no.nav.personbruker.dittnav.e2e.debugging.MocksContainerLogs
+import no.nav.personbruker.dittnav.e2e.debugging.ProducerContainerLogs
 import no.nav.personbruker.dittnav.e2e.doknotifikasjonStopp.DoknotifikasjonStoppDTO
 import no.nav.personbruker.dittnav.e2e.innboks.InnboksDTO
 import no.nav.personbruker.dittnav.e2e.innboks.ProduceInnboksDTO
@@ -20,7 +23,13 @@ import org.amshove.kluent.`should be empty`
 import org.amshove.kluent.`should contain all`
 import org.amshove.kluent.`should not be empty`
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 
+@ExtendWith(
+    MocksContainerLogs::class,
+    ApiContainerLogs::class,
+    ProducerContainerLogs::class
+)
 class DoneIT: UsesTheCommonDockerComposeContext() {
 
     private val ident = "12345678901"
@@ -37,7 +46,7 @@ class DoneIT: UsesTheCommonDockerComposeContext() {
         `produser brukernotifikasjon`(tokenAt4, innboks, ProducerOperations.PRODUCE_INNBOKS)
 
         val activeOppgaveEvents: List<OppgaveDTO>? = `wait for events` {
-            `get events`(tokenAt4, ApiOperations.FETCH_OPPGAVE)
+            `get events`<List<OppgaveDTO>>(tokenAt4, ApiOperations.FETCH_OPPGAVE)
         }
         activeOppgaveEvents!!.`should not be empty`()
 
@@ -62,12 +71,12 @@ class DoneIT: UsesTheCommonDockerComposeContext() {
         `produser brukernotifikasjon`(tokenAt4, oppgave2, ProducerOperations.PRODUCE_OPPGAVE)
 
         val activeOppgaveEvents: List<OppgaveDTO>? = `wait for events` {
-            `get events`(tokenAt4, ApiOperations.FETCH_OPPGAVE)
+            `get events`<List<OppgaveDTO>>(tokenAt4, ApiOperations.FETCH_OPPGAVE)
         }
         activeOppgaveEvents!!.`should not be empty`()
 
         val activeBeskjedEvents: List<BeskjedDTO>? = `wait for events` {
-            `get events`(tokenAt4, ApiOperations.FETCH_BESKJED)
+            `get events`<List<BeskjedDTO>>(tokenAt4, ApiOperations.FETCH_BESKJED)
         }
         activeBeskjedEvents!!.`should not be empty`()
 
@@ -97,7 +106,7 @@ class DoneIT: UsesTheCommonDockerComposeContext() {
 
     private fun `verify no active oppgave-events`(token: TokenInfo) {
         val inactiveOppgaveEvents: List<OppgaveDTO>? = `wait for events` {
-            `get events`(token, ApiOperations.FETCH_OPPGAVE_INACTIVE)
+            `get events`<List<OppgaveDTO>>(token, ApiOperations.FETCH_OPPGAVE_INACTIVE)
         }
         inactiveOppgaveEvents!!.`should not be empty`()
 
@@ -107,7 +116,7 @@ class DoneIT: UsesTheCommonDockerComposeContext() {
 
     private fun `verify no active beskjed-events`(token: TokenInfo) {
         val inactiveBeskjedEvents: List<BeskjedDTO>? = `wait for events` {
-            `get events`(token, ApiOperations.FETCH_BESKJED_INACTIVE)
+            `get events`<List<BeskjedDTO>>(token, ApiOperations.FETCH_BESKJED_INACTIVE)
         }
         inactiveBeskjedEvents!!.`should not be empty`()
 
@@ -117,7 +126,7 @@ class DoneIT: UsesTheCommonDockerComposeContext() {
 
     private fun `verify no active innboks-events`(token: TokenInfo) {
         val inactiveInnboksEvents: List<InnboksDTO>? = `wait for events` {
-            `get events`(token, ApiOperations.FETCH_INNBOKS_INACTIVE)
+            `get events`<List<InnboksDTO>>(token, ApiOperations.FETCH_INNBOKS_INACTIVE)
         }
         inactiveInnboksEvents!!.`should not be empty`()
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/done/PrintContainerLogsOnErrorsTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/done/PrintContainerLogsOnErrorsTest.kt
@@ -1,0 +1,59 @@
+package no.nav.personbruker.dittnav.e2e.done
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
+import no.nav.personbruker.dittnav.e2e.debugging.*
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.shouldNotBeEmpty
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtensionContext
+
+class PrintContainerLogsOnErrorsTest {
+
+    @Test
+    fun `Skal hente ut logger for riktig container per klasse`() {
+        AggregatorContainerLogs().service `should be equal to` ServiceConfiguration.AGGREGATOR
+        ApiContainerLogs().service `should be equal to` ServiceConfiguration.API
+        BrukernotifikasjonbestillerContainerLogs().service `should be equal to` ServiceConfiguration.BRUKERNOTIFIKASJONBESTILLER
+        DekoratorenContainerLogs().service `should be equal to` ServiceConfiguration.DEKORATOREN
+        FrontendContainerLogs().service `should be equal to` ServiceConfiguration.FRONTEND
+        HandlerContainerLogs().service `should be equal to` ServiceConfiguration.HANDLER
+        LegacyContainerLogs().service `should be equal to` ServiceConfiguration.LEGACY
+        MocksContainerLogs().service `should be equal to` ServiceConfiguration.MOCKS
+        OidcProviderContainerLogs().service `should be equal to` ServiceConfiguration.OIDC_PROVIDER
+        OidcProviderGuiContainerLogs().service `should be equal to` ServiceConfiguration.OIDC_PROVIDER_GUI
+        ProducerContainerLogs().service `should be equal to` ServiceConfiguration.PRODUCER
+        TidslinjeContainerLogs().service `should be equal to` ServiceConfiguration.TIDSLINJE
+        VarselbestillerContainerLogs().service `should be equal to` ServiceConfiguration.VARSELBESTILLER
+    }
+
+    @Test
+    fun `Skal lagre navnet paa tester som feiler`() {
+        val containerLogger = ApiContainerLogs()
+        val context = mockk<ExtensionContext>()
+        val expectedNavnPaaFeilendeTest = "Navnet på testen som feilet"
+        every { context.displayName } returns expectedNavnPaaFeilendeTest
+        val exception = Exception("Simulert feil i en test.")
+
+        containerLogger.testFailed(context, exception)
+
+        containerLogger.faildTests.shouldNotBeEmpty()
+        containerLogger.faildTests[0] `should be equal to` expectedNavnPaaFeilendeTest
+    }
+
+    @Test
+    fun `Skal lagre navnet paa tester som blir avbrutt`() {
+        val containerLogger = ApiContainerLogs()
+        val context = mockk<ExtensionContext>()
+        val expectedNavnPaaFeilendeTest = "Navnet på testen som feilet"
+        every { context.displayName } returns expectedNavnPaaFeilendeTest
+        val exception = Exception("Simulert feil i en test.")
+
+        containerLogger.testAborted(context, exception)
+
+        containerLogger.faildTests.shouldNotBeEmpty()
+        containerLogger.faildTests[0] `should be equal to` expectedNavnPaaFeilendeTest
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/innboks/InnboksIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/innboks/InnboksIT.kt
@@ -1,16 +1,23 @@
 package no.nav.personbruker.dittnav.e2e.innboks
 
-import io.ktor.client.statement.HttpResponse
-import io.ktor.http.HttpStatusCode
+import io.ktor.client.statement.*
+import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
 import no.nav.personbruker.dittnav.e2e.config.UsesTheCommonDockerComposeContext
+import no.nav.personbruker.dittnav.e2e.debugging.ApiContainerLogs
+import no.nav.personbruker.dittnav.e2e.debugging.ProducerContainerLogs
 import no.nav.personbruker.dittnav.e2e.operations.ApiOperations
 import no.nav.personbruker.dittnav.e2e.operations.ProducerOperations
 import no.nav.personbruker.dittnav.e2e.security.TokenInfo
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 
+@ExtendWith(
+    ApiContainerLogs::class,
+    ProducerContainerLogs::class
+)
 class InnboksIT : UsesTheCommonDockerComposeContext() {
 
     private val ident = "12345678901"
@@ -45,7 +52,12 @@ class InnboksIT : UsesTheCommonDockerComposeContext() {
 
     private fun `produce innboks-event at level`(originalInnboksEvent: ProduceInnboksDTO, token: TokenInfo) {
         runBlocking {
-            client.post<HttpResponse>(ServiceConfiguration.PRODUCER, ProducerOperations.PRODUCE_INNBOKS, originalInnboksEvent, token)
+            client.post<HttpResponse>(
+                ServiceConfiguration.PRODUCER,
+                ProducerOperations.PRODUCE_INNBOKS,
+                originalInnboksEvent,
+                token
+            )
         }.status `should be equal to` HttpStatusCode.OK
     }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/oppgave/OppgaveIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/oppgave/OppgaveIT.kt
@@ -5,6 +5,9 @@ import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
 import no.nav.personbruker.dittnav.e2e.config.UsesTheCommonDockerComposeContext
+import no.nav.personbruker.dittnav.e2e.debugging.ApiContainerLogs
+import no.nav.personbruker.dittnav.e2e.debugging.MocksContainerLogs
+import no.nav.personbruker.dittnav.e2e.debugging.ProducerContainerLogs
 import no.nav.personbruker.dittnav.e2e.doknotifikasjon.DoknotifikasjonDTO
 import no.nav.personbruker.dittnav.e2e.operations.ApiOperations
 import no.nav.personbruker.dittnav.e2e.operations.ProducerOperations
@@ -13,7 +16,13 @@ import no.nav.personbruker.dittnav.e2e.security.TokenInfo
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should contain all`
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 
+@ExtendWith(
+    ApiContainerLogs::class,
+    MocksContainerLogs::class,
+    ProducerContainerLogs::class
+)
 internal class OppgaveIT : UsesTheCommonDockerComposeContext() {
 
     private val ident = "12345678901"
@@ -58,8 +67,8 @@ internal class OppgaveIT : UsesTheCommonDockerComposeContext() {
         }
 
         val doknotifikasjonerToMatch = listOf(
-                DoknotifikasjonDTO("O-username-${activeOppgave!![0].eventId}"),
-                DoknotifikasjonDTO("O-username-${activeOppgave[1].eventId}")
+            DoknotifikasjonDTO("O-username-${activeOppgave!![0].eventId}"),
+            DoknotifikasjonDTO("O-username-${activeOppgave[1].eventId}")
         )
 
         val doknotifikasjoner = `wait for values to be returned`(doknotifikasjonerToMatch) {
@@ -71,7 +80,12 @@ internal class OppgaveIT : UsesTheCommonDockerComposeContext() {
 
     private fun `produce oppgave at level`(originalOppgave: ProduceOppgaveDTO, token: TokenInfo) {
         runBlocking {
-            client.post<HttpResponse>(ServiceConfiguration.PRODUCER, ProducerOperations.PRODUCE_OPPGAVE, originalOppgave, token)
+            client.post<HttpResponse>(
+                ServiceConfiguration.PRODUCER,
+                ProducerOperations.PRODUCE_OPPGAVE,
+                originalOppgave,
+                token
+            )
         }.status `should be equal to` HttpStatusCode.OK
     }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/readiness/ReadinessIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/readiness/ReadinessIT.kt
@@ -5,13 +5,28 @@ import io.ktor.http.HttpStatusCode.Companion.OK
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
 import no.nav.personbruker.dittnav.e2e.config.UsesTheCommonDockerComposeContext
+import no.nav.personbruker.dittnav.e2e.debugging.*
 import no.nav.personbruker.dittnav.e2e.operations.*
 import org.amshove.kluent.`should be equal to`
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.AnyOf.anyOf
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 
+@ExtendWith(
+    ApiContainerLogs::class,
+    LegacyContainerLogs::class,
+    HandlerContainerLogs::class,
+    AggregatorContainerLogs::class,
+    ProducerContainerLogs::class,
+    FrontendContainerLogs::class,
+    TidslinjeContainerLogs::class,
+    VarselbestillerContainerLogs::class,
+    BrukernotifikasjonbestillerContainerLogs::class,
+    DekoratorenContainerLogs::class,
+    MocksContainerLogs::class
+)
 internal class ReadinessIT : UsesTheCommonDockerComposeContext() {
 
     @Test

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/security/SecurityIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/security/SecurityIT.kt
@@ -9,12 +9,21 @@ import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.e2e.beskjed.ProduceBeskjedDTO
 import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
 import no.nav.personbruker.dittnav.e2e.config.UsesTheCommonDockerComposeContext
+import no.nav.personbruker.dittnav.e2e.debugging.*
 import no.nav.personbruker.dittnav.e2e.operations.*
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should be in`
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 
+@ExtendWith(
+    ApiContainerLogs::class,
+    HandlerContainerLogs::class,
+    LegacyContainerLogs::class,
+    ProducerContainerLogs::class,
+    TidslinjeContainerLogs::class
+)
 internal class SecurityIT : UsesTheCommonDockerComposeContext() {
 
     private lateinit var tokenAtLevel3: TokenInfo

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/security/SecurityIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/security/SecurityIT.kt
@@ -87,22 +87,18 @@ internal class SecurityIT : UsesTheCommonDockerComposeContext() {
         val operation = ProducerOperations.PRODUCE_BESKJED
         runBlocking {
             val unauthResponse = client.postWithoutAuth<HttpResponse>(producer, operation, data)
-            printServiceLogIfNotExpectedResult(producer, unauthResponse, Unauthorized)
             unauthResponse.status `should be equal to` Unauthorized
 
             val authResponse3 = client.post<HttpResponse>(producer, operation, data, tokenAtLevel3)
-            printServiceLogIfNotExpectedResult(producer, authResponse3, OK)
             authResponse3.status `should be equal to` OK
 
             val authResponse4 = client.post<HttpResponse>(producer, operation, data, tokenAtLevel4)
-            printServiceLogIfNotExpectedResult(producer, authResponse4, OK)
             authResponse4.status `should be equal to` OK
         }
     }
 
     private suspend fun assertThatTheRequestWasDenied(service: ServiceConfiguration, operation: ServiceOperation) {
         val unauthResponse = client.getWithoutAuth<HttpResponse>(service, operation)
-        printServiceLogIfNotExpectedResult(service, unauthResponse, Unauthorized)
         unauthResponse.status `should be equal to` Unauthorized
     }
 
@@ -114,19 +110,7 @@ internal class SecurityIT : UsesTheCommonDockerComposeContext() {
         val authResponse = client.get<HttpResponse>(service, operation, tokenInfo, parameters)
 
 
-        printServiceLogIfNotInExpectedResults(service, authResponse, definitionOfAccepted)
         authResponse.status `should be in` definitionOfAccepted
     }
 
-    private fun printServiceLogIfNotExpectedResult(service: ServiceConfiguration, actualResponse: HttpResponse, expectedResponse: HttpStatusCode) {
-        if (actualResponse.status != expectedResponse) {
-            println("Container log for the service $service:\n ${dockerComposeContext.getLogsFor(service)}")
-        }
-    }
-
-    private fun printServiceLogIfNotInExpectedResults(service: ServiceConfiguration, actualResponse: HttpResponse, expectedResponse: List<HttpStatusCode>) {
-        if (actualResponse.status !in expectedResponse) {
-            println("Container log for the service $service:\n ${dockerComposeContext.getLogsFor(service)}")
-        }
-    }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/tidslinje/TidslinjeIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/tidslinje/TidslinjeIT.kt
@@ -7,6 +7,7 @@ import no.nav.personbruker.dittnav.e2e.beskjed.ProduceBeskjedDTO
 import no.nav.personbruker.dittnav.e2e.client.BrukernotifikasjonDTO
 import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
 import no.nav.personbruker.dittnav.e2e.config.UsesTheCommonDockerComposeContext
+import no.nav.personbruker.dittnav.e2e.debugging.*
 import no.nav.personbruker.dittnav.e2e.operations.ProducerOperations
 import no.nav.personbruker.dittnav.e2e.operations.ServiceOperation
 import no.nav.personbruker.dittnav.e2e.operations.TidslinjeOperations
@@ -14,7 +15,12 @@ import no.nav.personbruker.dittnav.e2e.oppgave.ProduceOppgaveDTO
 import no.nav.personbruker.dittnav.e2e.security.TokenInfo
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 
+@ExtendWith(
+    ProducerContainerLogs::class,
+    TidslinjeContainerLogs::class
+)
 class TidslinjeIT : UsesTheCommonDockerComposeContext() {
 
     private val ident = "12345678901"

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </root>
 

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>
 


### PR DESCRIPTION
Opprettet JUnit-extensions som sørger for å logge containerloggen for de tjenestene som brukes i en e2e-test. Slik at hvis en e2e-test feiler, så vil man finne loggene for alle container-ene som testen er avhengig av. Målet er at vi da enkelt skal kunne se hva som er den egentlige grunnen til at testen feilet.

Hver e2e-test må spesifisere hvilke containere den bruker, dette gjøres med å bruke annotasjonen `@ExtendWith` angi klassen som kan printe loggen for den containeren. F.eks. `@ExtendWith(ApiContainerLogs::class)` for å få container-loggene for tjenesten Api. Angi alle containere som testen bruker.

PB-853. Printing av logger for relevante containere i e2e