### PR TITLE
Bytt til nytt PAT

### DIFF
--- a/.github/workflows/on-dispatch-run-test.yml
+++ b/.github/workflows/on-dispatch-run-test.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.READ_PACKAGES_PAT }}
+          password: ${{ secrets.READER_TOKEN }}
       - name: Docker pull
         run: docker-compose pull
       - name: Run end-to-end-tests


### PR DESCRIPTION
Vi er i ferd med å fase ut READ_PACKAGES_PAT, og ønsker derfor at dere bruker READER_TOKEN i stedet.
