### PR TITLE
Fjerne jcenter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,25 +1,23 @@
 plugins {
     kotlin("jvm") version Kotlin.version
+    kotlin("plugin.serialization") version Kotlin.version
 }
 
 group = "no.nav.personbruker.dittnav"
 version = "1.0-SNAPSHOT"
 
 repositories {
-    jcenter()
     mavenCentral()
 }
 
 dependencies {
     implementation(Auth0.javajwt)
-    implementation(Jackson.dataTypeJsr310)
     implementation(Ktor.clientApache)
-    implementation(Ktor.clientJackson) {
-        exclude("org.jetbrains.kotlin", "kotlin-reflect")
-    }
     implementation(Ktor.clientJson)
     implementation(Ktor.clientLogging)
     implementation(Ktor.clientLoggingJvm)
+    implementation(Ktor.clientSerializationJvm)
+    implementation(Ktor.serialization)
     implementation(Logback.classic)
 
     testImplementation(Awaitility.awaitilityKotlin)

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,11 +3,11 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
     maven("https://jitpack.io")
 }
 
-val dittNavDependenciesVersion = "2021.01.18-09.14-fa1d055e5865"
+val dittNavDependenciesVersion = "2022.01.27-13.16-8429354bdc72"
 
 dependencies {
     implementation("com.github.navikt:dittnav-dependencies:$dittNavDependenciesVersion")

--- a/src/main/kotlin/no/nav/personbruker/dittnav/e2e/client/JsonConfig.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/e2e/client/JsonConfig.kt
@@ -1,21 +1,10 @@
 package no.nav.personbruker.dittnav.e2e.client
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import io.ktor.client.features.json.*
+import kotlinx.serialization.json.Json
 
-fun buildJsonSerializer(): JacksonSerializer {
-    return JacksonSerializer {
-        enableDittNavJsonConfig()
+fun json(ignoreUnknownKeys: Boolean = false): Json {
+    return Json {
+        this.ignoreUnknownKeys = ignoreUnknownKeys
+        this.encodeDefaults = true
     }
-}
-
-fun ObjectMapper.enableDittNavJsonConfig() {
-    registerModule(JavaTimeModule())
-    registerKotlinModule()
-    disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-    disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/e2e/client/httpClient.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/e2e/client/httpClient.kt
@@ -2,7 +2,7 @@ package no.nav.personbruker.dittnav.e2e.client
 
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.apache.Apache
-import io.ktor.client.features.HttpTimeout
+import io.ktor.client.features.*
 import io.ktor.client.features.cookies.AcceptAllCookiesStorage
 import io.ktor.client.features.cookies.HttpCookies
 import io.ktor.client.features.json.JsonFeature
@@ -41,5 +41,6 @@ suspend inline fun <reified T> HttpClient.get(url: URL): T = withContext(Dispatc
     request<T> {
         url(url)
         method = HttpMethod.Get
+        expectSuccess = false
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/e2e/client/httpClient.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/e2e/client/httpClient.kt
@@ -5,20 +5,19 @@ import io.ktor.client.engine.apache.Apache
 import io.ktor.client.features.HttpTimeout
 import io.ktor.client.features.cookies.AcceptAllCookiesStorage
 import io.ktor.client.features.cookies.HttpCookies
-import io.ktor.client.features.json.JacksonSerializer
 import io.ktor.client.features.json.JsonFeature
+import io.ktor.client.features.json.serializer.*
 import io.ktor.client.features.logging.DEFAULT
 import io.ktor.client.features.logging.LogLevel
 import io.ktor.client.features.logging.Logger
 import io.ktor.client.features.logging.Logging
-import io.ktor.client.request.request
-import io.ktor.client.request.url
-import io.ktor.http.HttpMethod
+import io.ktor.client.request.*
+import io.ktor.http.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.net.URL
 
-fun buildHttpClient(): HttpClient {
+fun buildHttpClient(jsonSerializer: KotlinxSerializer = KotlinxSerializer(json())): HttpClient {
     return HttpClient(Apache) {
         install(HttpCookies) {
             keepAllCookiesFromPreviousRequests()
@@ -28,7 +27,7 @@ fun buildHttpClient(): HttpClient {
             level = LogLevel.NONE
         }
         install(JsonFeature) {
-            serializer = buildJsonSerializer()
+            serializer = jsonSerializer
         }
         install(HttpTimeout)
     }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/e2e/security/TokenInfo.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/e2e/security/TokenInfo.kt
@@ -1,5 +1,8 @@
 package no.nav.personbruker.dittnav.e2e.security
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class TokenInfo(
     val access_token: String,
     val expires_in: Int,

--- a/src/main/kotlin/no/nav/personbruker/dittnav/e2e/serializer/ZonedDateTimeSerializer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/e2e/serializer/ZonedDateTimeSerializer.kt
@@ -1,0 +1,25 @@
+package no.nav.personbruker.dittnav.e2e.serializer
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+class ZonedDateTimeSerializer : KSerializer<ZonedDateTime> {
+
+    override fun deserialize(decoder: Decoder): ZonedDateTime {
+        val value = decoder.decodeString()
+        return ZonedDateTime.parse(value)
+    }
+
+    override fun serialize(encoder: Encoder, value: ZonedDateTime) {
+        encoder.encodeString(value.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
+    }
+
+    override val descriptor: SerialDescriptor
+        get() = PrimitiveSerialDescriptor("ZonedDateTime", PrimitiveKind.STRING)
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/beskjed/BeskjedDTO.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/beskjed/BeskjedDTO.kt
@@ -1,8 +1,13 @@
+@file:UseSerializers(ZonedDateTimeSerializer::class)
 package no.nav.personbruker.dittnav.e2e.beskjed
 
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
 import no.nav.personbruker.dittnav.e2e.client.BrukernotifikasjonDTO
+import no.nav.personbruker.dittnav.e2e.serializer.ZonedDateTimeSerializer
 import java.time.ZonedDateTime
 
+@Serializable
 data class BeskjedDTO(
         val uid: String,
         val eventTidspunkt: ZonedDateTime,
@@ -11,5 +16,7 @@ data class BeskjedDTO(
         val link: String,
         val produsent: String?,
         val sistOppdatert: ZonedDateTime,
-        val sikkerhetsnivaa: Int
+        val sikkerhetsnivaa: Int,
+        val aktiv: Boolean,
+        val grupperingsId: String
 ) : BrukernotifikasjonDTO()

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/beskjed/ProduceBeskjedDTO.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/beskjed/ProduceBeskjedDTO.kt
@@ -1,7 +1,9 @@
 package no.nav.personbruker.dittnav.e2e.beskjed
 
+import kotlinx.serialization.Serializable
 import no.nav.personbruker.dittnav.e2e.client.BrukernotifikasjonDTO
 
+@Serializable
 data class ProduceBeskjedDTO(
         val tekst: String,
         val link: String = "http://dummylenke.no",

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/client/BrukernotifikasjonDTO.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/client/BrukernotifikasjonDTO.kt
@@ -1,3 +1,6 @@
 package no.nav.personbruker.dittnav.e2e.client
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 abstract class BrukernotifikasjonDTO

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/client/RestClient.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/client/RestClient.kt
@@ -1,6 +1,7 @@
 package no.nav.personbruker.dittnav.e2e.client
 
 import io.ktor.client.HttpClient
+import io.ktor.client.features.*
 import io.ktor.client.request.*
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
@@ -61,6 +62,7 @@ class RestClient(val httpClient: HttpClient) {
                 method = HttpMethod.Post
                 contentType(ContentType.Application.Json)
                 body = data
+                expectSuccess = false
             }
 
         } catch (e: Exception) {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/doknotifikasjon/DoknotifikasjonDTO.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/doknotifikasjon/DoknotifikasjonDTO.kt
@@ -1,5 +1,8 @@
 package no.nav.personbruker.dittnav.e2e.doknotifikasjon
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class DoknotifikasjonDTO(
         val bestillingsId: String
 )

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/doknotifikasjonStopp/DoknotifikasjonStoppDTO.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/doknotifikasjonStopp/DoknotifikasjonStoppDTO.kt
@@ -1,5 +1,8 @@
 package no.nav.personbruker.dittnav.e2e.doknotifikasjonStopp
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class DoknotifikasjonStoppDTO(
         val bestillingsId: String
 )

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/done/ProduceDoneDTO.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/done/ProduceDoneDTO.kt
@@ -1,5 +1,7 @@
 package no.nav.personbruker.dittnav.e2e.done
 
+import kotlinx.serialization.Serializable
 import no.nav.personbruker.dittnav.e2e.client.BrukernotifikasjonDTO
 
+@Serializable
 data class ProduceDoneDTO(val uid: String = "", val eventId: String = "") : BrukernotifikasjonDTO()

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/innboks/InnboksDTO.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/innboks/InnboksDTO.kt
@@ -1,7 +1,12 @@
+@file:UseSerializers(ZonedDateTimeSerializer::class)
 package no.nav.personbruker.dittnav.e2e.innboks
 
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import no.nav.personbruker.dittnav.e2e.serializer.ZonedDateTimeSerializer
 import java.time.ZonedDateTime
 
+@Serializable
 data class InnboksDTO(
         val uid: String?,
         val eventTidspunkt: ZonedDateTime,

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/innboks/ProduceInnboksDTO.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/innboks/ProduceInnboksDTO.kt
@@ -1,7 +1,9 @@
 package no.nav.personbruker.dittnav.e2e.innboks
 
+import kotlinx.serialization.Serializable
 import no.nav.personbruker.dittnav.e2e.client.BrukernotifikasjonDTO
 
+@Serializable
 data class ProduceInnboksDTO(
         val tekst: String,
         val link: String = "http://dummylenke.no",

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/oppgave/OppgaveDTO.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/oppgave/OppgaveDTO.kt
@@ -1,7 +1,12 @@
+@file:UseSerializers(ZonedDateTimeSerializer::class)
 package no.nav.personbruker.dittnav.e2e.oppgave
 
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import no.nav.personbruker.dittnav.e2e.serializer.ZonedDateTimeSerializer
 import java.time.ZonedDateTime
 
+@Serializable
 data class OppgaveDTO(
         val uid: String?,
         val eventTidspunkt: ZonedDateTime,
@@ -10,5 +15,7 @@ data class OppgaveDTO(
         val link: String,
         val produsent: String?,
         val sistOppdatert: ZonedDateTime,
-        val sikkerhetsnivaa: Int
+        val sikkerhetsnivaa: Int,
+        val aktiv: Boolean,
+        val grupperingsId: String
 )

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/oppgave/ProduceOppgaveDTO.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/oppgave/ProduceOppgaveDTO.kt
@@ -1,7 +1,9 @@
 package no.nav.personbruker.dittnav.e2e.oppgave
 
+import kotlinx.serialization.Serializable
 import no.nav.personbruker.dittnav.e2e.client.BrukernotifikasjonDTO
 
+@Serializable
 data class ProduceOppgaveDTO(
         val tekst: String,
         val link: String = "http://dummylenke.no",

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/tidslinje/Brukernotifikasjon.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/tidslinje/Brukernotifikasjon.kt
@@ -1,8 +1,9 @@
+
 package no.nav.personbruker.dittnav.e2e.tidslinje
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import kotlinx.serialization.Serializable
 
-@JsonIgnoreProperties(ignoreUnknown = true)
+@Serializable
 data class Brukernotifikasjon(
         val type: String,
         val sikkerhetsnivaa: Int

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/tidslinje/ProduceStatusoppdateringDTO.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/tidslinje/ProduceStatusoppdateringDTO.kt
@@ -1,7 +1,9 @@
 package no.nav.personbruker.dittnav.e2e.tidslinje
 
+import kotlinx.serialization.Serializable
 import no.nav.personbruker.dittnav.e2e.client.BrukernotifikasjonDTO
 
+@Serializable
 data class ProduceStatusoppdateringDTO(
         val statusIntern: String,
         val grupperingsid: String = "123",

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/tidslinje/TidslinjeIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/tidslinje/TidslinjeIT.kt
@@ -1,13 +1,18 @@
 package no.nav.personbruker.dittnav.e2e.tidslinje
 
-import io.ktor.client.statement.HttpResponse
-import io.ktor.http.HttpStatusCode
+import io.ktor.client.features.json.serializer.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.e2e.beskjed.ProduceBeskjedDTO
 import no.nav.personbruker.dittnav.e2e.client.BrukernotifikasjonDTO
+import no.nav.personbruker.dittnav.e2e.client.RestClient
+import no.nav.personbruker.dittnav.e2e.client.buildHttpClient
+import no.nav.personbruker.dittnav.e2e.client.json
 import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
 import no.nav.personbruker.dittnav.e2e.config.UsesTheCommonDockerComposeContext
-import no.nav.personbruker.dittnav.e2e.debugging.*
+import no.nav.personbruker.dittnav.e2e.debugging.ProducerContainerLogs
+import no.nav.personbruker.dittnav.e2e.debugging.TidslinjeContainerLogs
 import no.nav.personbruker.dittnav.e2e.operations.ProducerOperations
 import no.nav.personbruker.dittnav.e2e.operations.ServiceOperation
 import no.nav.personbruker.dittnav.e2e.operations.TidslinjeOperations
@@ -25,6 +30,8 @@ class TidslinjeIT : UsesTheCommonDockerComposeContext() {
 
     private val ident = "12345678901"
     private val produsent = "produsent"
+
+    private val httpClient = RestClient(buildHttpClient(KotlinxSerializer(json(ignoreUnknownKeys = true))))
 
     @Test
     fun `Skal hente alle eventer som er gruppert sammen og er paa sikkerhetsnivaa 4`() {
@@ -107,7 +114,7 @@ class TidslinjeIT : UsesTheCommonDockerComposeContext() {
 
     private fun `produce event at level`(originalEvent: BrukernotifikasjonDTO, operation: ServiceOperation, token: TokenInfo) {
         runBlocking {
-            client.post<HttpResponse>(ServiceConfiguration.PRODUCER, operation, originalEvent, token)
+            httpClient.post<HttpResponse>(ServiceConfiguration.PRODUCER, operation, originalEvent, token)
         }.status `should be equal to` HttpStatusCode.OK
     }
 
@@ -116,7 +123,7 @@ class TidslinjeIT : UsesTheCommonDockerComposeContext() {
                                             parameters: Map<String, String>): List<Brukernotifikasjon> {
         return runBlocking {
             val response =
-                    client.get<List<Brukernotifikasjon>>(
+                    httpClient.get<List<Brukernotifikasjon>>(
                             ServiceConfiguration.TIDSLINJE,
                             operation,
                             token,


### PR DESCRIPTION
- Fjerner jCenter
- Bytter ut Jackson med Kotlinx-serialisering, tilsvarende de andre appene våre.
- Sjekk på status-kode som vi baserte en del av testene på fungerte ikke etter med Ktor >= 1.5. Problemet oppstod dermed for en stund siden, men siden e2e-testene her brukte en veldig gammel versjon av dittnav-dependencies ble det først synlig nå når jeg bumpet til siste versjon (som da tok oss fra 1.4 til 1.6)
- Oppdatert DTO-er slik at de stemmer med felter som nå er i eventene.