### PR TITLE
Kjøring av e2e-tester med GCP-versjoner

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -289,7 +289,7 @@ services:
       dittnav.docker-internal:
         aliases:
           - producer.dittnav.docker-internal
-    image: "docker.io/navikt/producer:tms1"
+    image: "ghcr.io/navikt/tms-event-test-producer/tms-event-test-producer:latest"
     mem_limit: '512m'
     mem_reservation: '256m'
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,6 +171,8 @@ services:
       - "8092:8080"
     env_file:
       - .env
+      - env/.tokenx.validate.env
+      - env/.azure.validate.env
     environment:
       DB_EVENTHANDLER_HOST: ${DB_HOST}
       DB_EVENTHANDLER_DATABASE: ${DB_NAME_BRUKERNOTIFIKASJON_CACHE}
@@ -178,6 +180,8 @@ services:
       DB_EVENTHANDLER_PASSWORD: ${DB_PASSWORD}
       DB_EVENTHANDLER_PORT: ${DB_PORT}
       OPEN_INPUT_DONE_TOPIC: "min-side.aapen-brukernotifikasjon-done-v1"
+      TOKEN_X_CLIENT_ID: "dittnav-event-handler-clientid"
+      AZURE_APP_CLIENT_ID: "dittnav-event-handler-clientid"
       # variabler for on-prem
       DB_NAME: ${DB_NAME_BRUKERNOTIFIKASJON_CACHE}
     depends_on:
@@ -213,7 +217,7 @@ services:
       PERSONALIA_API_URL: "http://mocks.dittnav.docker-internal:8080/tms-personalia-api"
       PERSONALIA_API_CLIENT_ID: "tms-personalia-api-client-id"
       TOKEN_X_CLIENT_ID: "dittnav-api-client-id"
-      EVENTHANDLER_CLIENT_ID: "eventhandler-client-id"
+      EVENTHANDLER_CLIENT_ID: "dittnav-event-handler-clientid"
     depends_on:
       oidc-provider:
         condition: service_started
@@ -283,13 +287,14 @@ services:
       dittnav.docker-internal:
         aliases:
           - producer.dittnav.docker-internal
-    image: "ghcr.io/navikt/tms-event-test-producer/tms-event-test-producer:latest"
+    image: "docker.io/navikt/producer:tms1"
     mem_limit: '512m'
     mem_reservation: '256m'
     ports:
       - "8094:8080"
     env_file:
       - .env
+      - env/.tokenx.exchange.env
     environment:
       CORS_ALLOWED_ORIGINS: "localhost"
       DB_NAME: ${DB_NAME_BRUKERNOTIFIKASJON_CACHE}
@@ -299,7 +304,9 @@ services:
       OPEN_INPUT_STATUSOPPDATERING_TOPIC: "min-side.aapen-brukernotifikasjon-nyStatusoppdatering-v1"
       OPEN_INPUT_DONE_TOPIC: "min-side.aapen-brukernotifikasjon-done-v1"
       EVENT_HANDLER_URL: "http://handler.dittnav.docker-internal:8080"
-      EVENTHANDLER_CLIENT_ID: "eventhandler-client-id"
+      EVENTHANDLER_CLIENT_ID: "dittnav-event-handler-clientid"
+      ENABLE_API: "true"
+      TOKEN_X_CLIENT_ID: "tms-event-test-producer-clientid"
     depends_on:
       - oidc-provider-gui
       - postgres
@@ -330,7 +337,7 @@ services:
       dittnav.docker-internal:
         aliases:
           - auth-mock.dittnav.docker-internal
-    image: "ghcr.io/navikt/tms-auth-mock/tms-auth-mock:latest"
+    image: "docker.io/navikt/mock:client4"
     mem_limit: '768m'
     mem_reservation: '240m'
     ports:
@@ -375,7 +382,7 @@ services:
       dittnav.docker-internal:
         aliases:
           - frontend.dittnav.docker-internal
-    image: "ghcr.io/navikt/dittnav/dittnav:latest"
+    image: "ghcr.io/navikt/dittnav/dittnav:20220221163116-8c57982"
     mem_limit: '768m'
     mem_reservation: '512m'
     ports:
@@ -407,6 +414,8 @@ services:
       TIDSLINJE_PRODUSENT: "produsent"
       VEIENTILARBEID_URL: "http://dummyVeientilarbeid.nav.no"
       MINE_SAKER_URL: "https://dummy-minesaker.nav.no"
+      INNBOKS_URL: "https://dummyInnboks.nav.no"
+      UTBETALINGSOVERSIKT_URL: "https://dummyUtbetalingsoversikt.nav.no"
       # Dette er et lite hack for å slippe at loggen oversvømmes av meldinger om at sensu-hosten ikke finnes.
       sensu_client_host: "localhost"
       sensu_client_port: "8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -385,7 +385,7 @@ services:
       dittnav.docker-internal:
         aliases:
           - frontend.dittnav.docker-internal
-    image: "ghcr.io/navikt/dittnav/dittnav:20220221163116-8c57982"
+    image: "ghcr.io/navikt/dittnav/dittnav:latest"
     mem_limit: '768m'
     mem_reservation: '512m'
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -340,7 +340,7 @@ services:
       dittnav.docker-internal:
         aliases:
           - auth-mock.dittnav.docker-internal
-    image: "docker.io/navikt/mock:client4"
+    image: "ghcr.io/navikt/tms-auth-mock/tms-auth-mock:latest"
     mem_limit: '768m'
     mem_reservation: '240m'
     ports:

--- a/src/main/kotlin/no/nav/personbruker/dittnav/e2e/security/BearerToken.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/e2e/security/BearerToken.kt
@@ -1,0 +1,10 @@
+package no.nav.personbruker.dittnav.e2e.security
+
+data class BearerToken(
+        val token: String
+) {
+
+    override fun toString(): String {
+        return "Bearer $token"
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/e2e/security/TokenFetcher.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/e2e/security/TokenFetcher.kt
@@ -43,17 +43,17 @@ class TokenFetcher(private val audience: String,
     }
 
     fun exchangeToken(clientId: String, audience: String, tokenInfo: TokenInfo): TokenXToken = runBlocking {
-        val clientAssertion = getClientAssertion(clientId, audience)
+        val clientAssertion = getSignedAssertion(clientId, audience)
 
         val urlParameters = ParametersBuilder().apply {
             append("client_assertion", clientAssertion)
             append("subject_token", tokenInfo.id_token)
             append("audience", audience)
         }.build()
-        return@runBlocking exhange(TextContent(urlParameters.formUrlEncode(), ContentType.Application.FormUrlEncoded))
+        return@runBlocking fetchExchangedToken(TextContent(urlParameters.formUrlEncode(), ContentType.Application.FormUrlEncoded))
     }
 
-    private suspend fun getClientAssertion(clientId: String, audience: String): String {
+    private suspend fun getSignedAssertion(clientId: String, audience: String): String {
         val completeUrlToHit = "$authMockUrl/tokendings/clientassertion"
         return client.request {
             url(completeUrlToHit)
@@ -64,7 +64,7 @@ class TokenFetcher(private val audience: String,
         }
     }
 
-    private suspend fun exhange(content: TextContent): TokenXToken {
+    private suspend fun fetchExchangedToken(content: TextContent): TokenXToken {
         val completeUrlToHit = "$authMockUrl/tokendings/token"
         return try {
             client.request{

--- a/src/main/kotlin/no/nav/personbruker/dittnav/e2e/security/TokenFetcher.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/e2e/security/TokenFetcher.kt
@@ -4,9 +4,11 @@ import io.ktor.client.features.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import io.ktor.http.content.*
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.e2e.client.buildHttpClient
 import no.nav.personbruker.dittnav.e2e.client.get
+import org.slf4j.LoggerFactory
 import java.net.URL
 import java.util.*
 
@@ -14,7 +16,10 @@ class TokenFetcher(private val audience: String,
                    private val clientSecret: String,
                    private val oidcProviderBaseUrl: String) {
 
+    private val log = LoggerFactory.getLogger(TokenFetcher::class.java)
+
     private val oidcProviderGuiUrl = "http://localhost:50000/callback"
+    private val authMockUrl = "http://localhost:9051"
 
     private val client = buildHttpClient()
 
@@ -34,6 +39,44 @@ class TokenFetcher(private val audience: String,
             fetcherException.addContext("ident", ident)
             fetcherException.addContext("sikkerhetsnivaa", sikkerhetsnivaa)
             throw fetcherException
+        }
+    }
+
+    fun exchangeToken(clientId: String, audience: String, tokenInfo: TokenInfo): TokenXToken = runBlocking {
+        val clientAssertion = getClientAssertion(clientId, audience)
+
+        val urlParameters = ParametersBuilder().apply {
+            append("client_assertion", clientAssertion)
+            append("subject_token", tokenInfo.id_token)
+            append("audience", audience)
+        }.build()
+        return@runBlocking exhange(TextContent(urlParameters.formUrlEncode(), ContentType.Application.FormUrlEncoded))
+    }
+
+    private suspend fun getClientAssertion(clientId: String, audience: String): String {
+        val completeUrlToHit = "$authMockUrl/tokendings/clientassertion"
+        return client.request {
+            url(completeUrlToHit)
+            method = HttpMethod.Get
+            expectSuccess = false
+            parameter("clientId", clientId)
+            parameter("audience", audience)
+        }
+    }
+
+    private suspend fun exhange(content: TextContent): TokenXToken {
+        val completeUrlToHit = "$authMockUrl/tokendings/token"
+        return try {
+            client.request{
+                url(completeUrlToHit)
+                method = HttpMethod.Post
+                expectSuccess = false
+                body = content
+            }
+        } catch (e: Exception) {
+            val msg = "Uventet feil skjedde mot auth-mock, klarte ikke å gjenomføre et kallet mot $completeUrlToHit"
+            log.error(msg)
+            throw e
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/e2e/security/TokenXToken.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/e2e/security/TokenXToken.kt
@@ -1,0 +1,12 @@
+package no.nav.personbruker.dittnav.e2e.security
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TokenXToken(
+        @SerialName("access_token") val accessToken: String,
+        @SerialName("issued_token_type") val issuedTokenType: String = "urn:ietf:params:oauth:token-type:access_token",
+        @SerialName("token_type") val tokenType: String = "Bearer",
+        @SerialName("expires_in") val expiresIn: Int = 3600
+)

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/beskjed/BeskjedIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/beskjed/BeskjedIT.kt
@@ -13,6 +13,7 @@ import no.nav.personbruker.dittnav.e2e.done.ProduceDoneDTO
 import no.nav.personbruker.dittnav.e2e.operations.ApiOperations
 import no.nav.personbruker.dittnav.e2e.operations.ProducerOperations
 import no.nav.personbruker.dittnav.e2e.operations.VarselOperations
+import no.nav.personbruker.dittnav.e2e.security.BearerToken
 import no.nav.personbruker.dittnav.e2e.security.TokenInfo
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should contain all`
@@ -113,20 +114,20 @@ internal class BeskjedIT : UsesTheCommonDockerComposeContext() {
                 ServiceConfiguration.PRODUCER,
                 ProducerOperations.PRODUCE_BESKJED,
                 originalBeskjed,
-                token
+                BearerToken(token.id_token)
             )
         }.status `should be equal to` HttpStatusCode.OK
     }
 
     private fun `produce done-event for beskjed`(originalDone: ProduceDoneDTO, token: TokenInfo) {
         runBlocking {
-            client.post<HttpResponse>(ServiceConfiguration.API, ApiOperations.PRODUCE_DONE, originalDone, token)
+            client.post<HttpResponse>(ServiceConfiguration.API, ApiOperations.PRODUCE_DONE, originalDone, BearerToken(token.id_token))
         }.status `should be equal to` HttpStatusCode.OK
     }
 
     private fun `get events`(token: TokenInfo, operation: ApiOperations): List<BeskjedDTO> {
         return runBlocking {
-            val response = client.get<List<BeskjedDTO>>(ServiceConfiguration.API, operation, token)
+            val response = client.get<List<BeskjedDTO>>(ServiceConfiguration.API, operation, BearerToken(token.id_token))
             response
         }
     }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/config/UsesTheCommonDockerComposeContext.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/config/UsesTheCommonDockerComposeContext.kt
@@ -16,8 +16,7 @@ import org.slf4j.LoggerFactory
 open class UsesTheCommonDockerComposeContext {
 
     val dockerComposeContext = DittNavDockerComposeCommonContext.instance
-    private val httpClient = buildHttpClient()
-    val client = RestClient(httpClient)
+    val client = RestClient(buildHttpClient())
 
     private val oidcproviderURL = dockerComposeContext.getBaseUrl(ServiceConfiguration.OIDC_PROVIDER).toString()
     private val log = LoggerFactory.getLogger(UsesTheCommonDockerComposeContext::class.java)

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/config/UsesTheCommonDockerComposeContext.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/config/UsesTheCommonDockerComposeContext.kt
@@ -16,10 +16,13 @@ import org.slf4j.LoggerFactory
 open class UsesTheCommonDockerComposeContext {
 
     val dockerComposeContext = DittNavDockerComposeCommonContext.instance
-    val client = RestClient(buildHttpClient())
+    private val httpClient = buildHttpClient()
+    val client = RestClient(httpClient)
 
     private val oidcproviderURL = dockerComposeContext.getBaseUrl(ServiceConfiguration.OIDC_PROVIDER).toString()
     private val log = LoggerFactory.getLogger(UsesTheCommonDockerComposeContext::class.java)
+
+    val dittnavEventHandlerClientId = "dittnav-event-handler-clientid"
 
     val tokenFetcher = TokenFetcher(
             audience = "stubOidcClient",

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/AuthMockContainerLogs.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/debugging/AuthMockContainerLogs.kt
@@ -1,0 +1,8 @@
+package no.nav.personbruker.dittnav.e2e.debugging
+
+import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
+
+class AuthMockContainerLogs : PrintContainerLogsOnErrors {
+    override val faildTests: MutableList<String> = mutableListOf()
+    override val service = ServiceConfiguration.AUTH_MOCK
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/done/DoneIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/done/DoneIT.kt
@@ -93,18 +93,18 @@ class DoneIT: UsesTheCommonDockerComposeContext() {
         `produser done-eventer for alle brukernotifikasjoner`(tokenAt4)
 
         val doknotifikasjonStoppForBeskjedToMatch = listOf(
-                DoknotifikasjonStoppDTO("B-username-${activeBeskjedEvents[0].eventId}"),
-                DoknotifikasjonStoppDTO("B-username-${activeBeskjedEvents[1].eventId}")
+                DoknotifikasjonStoppDTO("B-tms-event-test-producer-${activeBeskjedEvents[0].eventId}"),
+                DoknotifikasjonStoppDTO("B-tms-event-test-producer-${activeBeskjedEvents[1].eventId}")
         )
 
         val doknotifikasjonStoppForOppgaveToMatch = listOf(
-                DoknotifikasjonStoppDTO("O-username-${activeOppgaveEvents[0].eventId}"),
-                DoknotifikasjonStoppDTO("O-username-${activeOppgaveEvents[1].eventId}")
+                DoknotifikasjonStoppDTO("O-tms-event-test-producer-${activeOppgaveEvents[0].eventId}"),
+                DoknotifikasjonStoppDTO("O-tms-event-test-producer-${activeOppgaveEvents[1].eventId}")
         )
 
         val doknotifikasjonStoppForInnboksToMatch = listOf(
-                DoknotifikasjonStoppDTO("I-username-${activeInnboksEvents[0].eventId}"),
-                DoknotifikasjonStoppDTO("I-username-${activeInnboksEvents[1].eventId}")
+                DoknotifikasjonStoppDTO("I-tms-event-test-producer-${activeInnboksEvents[0].eventId}"),
+                DoknotifikasjonStoppDTO("I-tms-event-test-producer-${activeInnboksEvents[1].eventId}")
         )
 
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/done/DoneIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/done/DoneIT.kt
@@ -7,9 +7,7 @@ import no.nav.personbruker.dittnav.e2e.beskjed.ProduceBeskjedDTO
 import no.nav.personbruker.dittnav.e2e.client.BrukernotifikasjonDTO
 import no.nav.personbruker.dittnav.e2e.config.ServiceConfiguration
 import no.nav.personbruker.dittnav.e2e.config.UsesTheCommonDockerComposeContext
-import no.nav.personbruker.dittnav.e2e.debugging.ApiContainerLogs
-import no.nav.personbruker.dittnav.e2e.debugging.MocksContainerLogs
-import no.nav.personbruker.dittnav.e2e.debugging.ProducerContainerLogs
+import no.nav.personbruker.dittnav.e2e.debugging.*
 import no.nav.personbruker.dittnav.e2e.doknotifikasjonStopp.DoknotifikasjonStoppDTO
 import no.nav.personbruker.dittnav.e2e.innboks.InnboksDTO
 import no.nav.personbruker.dittnav.e2e.innboks.ProduceInnboksDTO
@@ -18,6 +16,7 @@ import no.nav.personbruker.dittnav.e2e.operations.ProducerOperations
 import no.nav.personbruker.dittnav.e2e.operations.VarselOperations
 import no.nav.personbruker.dittnav.e2e.oppgave.OppgaveDTO
 import no.nav.personbruker.dittnav.e2e.oppgave.ProduceOppgaveDTO
+import no.nav.personbruker.dittnav.e2e.security.BearerToken
 import no.nav.personbruker.dittnav.e2e.security.TokenInfo
 import org.amshove.kluent.`should be empty`
 import org.amshove.kluent.`should contain all`
@@ -28,7 +27,9 @@ import org.junit.jupiter.api.extension.ExtendWith
 @ExtendWith(
     MocksContainerLogs::class,
     ApiContainerLogs::class,
-    ProducerContainerLogs::class
+    ProducerContainerLogs::class,
+    HandlerContainerLogs::class,
+    VarselbestillerContainerLogs::class
 )
 class DoneIT: UsesTheCommonDockerComposeContext() {
 
@@ -156,19 +157,19 @@ class DoneIT: UsesTheCommonDockerComposeContext() {
 
     private fun `produser brukernotifikasjon`(token: TokenInfo, brukernotifikasjon: BrukernotifikasjonDTO, producerOperation: ProducerOperations) {
         runBlocking {
-            client.post<HttpResponse>(ServiceConfiguration.PRODUCER, producerOperation, brukernotifikasjon, token)
+            client.post<HttpResponse>(ServiceConfiguration.PRODUCER, producerOperation, brukernotifikasjon, BearerToken(token.id_token))
         }
     }
 
     private fun `produser done-eventer for alle brukernotifikasjoner`(token: TokenInfo) {
         runBlocking {
-            client.post<HttpResponse>(ServiceConfiguration.PRODUCER, ProducerOperations.PRODUCE_DONE_ALL, ProduceDoneDTO(), token)
+            client.post<HttpResponse>(ServiceConfiguration.PRODUCER, ProducerOperations.PRODUCE_DONE_ALL, ProduceDoneDTO(), BearerToken(token.id_token))
         }
     }
 
     private inline fun <reified T> `get events`(token: TokenInfo, apiOperation: ApiOperations): T {
         return runBlocking {
-            val response = client.get<T>(ServiceConfiguration.API, apiOperation, token)
+            val response = client.get<T>(ServiceConfiguration.API, apiOperation, BearerToken(token.id_token))
             response
         }
     }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/innboks/InnboksIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/innboks/InnboksIT.kt
@@ -11,6 +11,7 @@ import no.nav.personbruker.dittnav.e2e.doknotifikasjon.DoknotifikasjonDTO
 import no.nav.personbruker.dittnav.e2e.operations.ApiOperations
 import no.nav.personbruker.dittnav.e2e.operations.ProducerOperations
 import no.nav.personbruker.dittnav.e2e.operations.VarselOperations
+import no.nav.personbruker.dittnav.e2e.security.BearerToken
 import no.nav.personbruker.dittnav.e2e.security.TokenInfo
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should contain all`
@@ -82,7 +83,7 @@ class InnboksIT : UsesTheCommonDockerComposeContext() {
                 ServiceConfiguration.PRODUCER,
                 ProducerOperations.PRODUCE_INNBOKS,
                 originalInnboksEvent,
-                token
+                BearerToken(token.id_token)
             )
         }.status `should be equal to` HttpStatusCode.OK
     }
@@ -96,7 +97,7 @@ class InnboksIT : UsesTheCommonDockerComposeContext() {
 
     private fun `get events`(token: TokenInfo, operation: ApiOperations): List<InnboksDTO> {
         return runBlocking {
-            val response = client.get<List<InnboksDTO>>(ServiceConfiguration.API, operation, token)
+            val response = client.get<List<InnboksDTO>>(ServiceConfiguration.API, operation, BearerToken(token.id_token))
             response
         }
     }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/operations/AuthMockOperations.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/operations/AuthMockOperations.kt
@@ -1,0 +1,8 @@
+package no.nav.personbruker.dittnav.e2e.operations
+
+enum class AuthMockOperations(override val path: String) : ServiceOperation {
+    IS_ALIVE("/internal/isAlive"),
+    IS_READY("/internal/isReady"),
+    CLIENT_ASSERTION("/tokendings/clientassertion"),
+    EXCHANGE_TOKEN("/tokendings/token")
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/oppgave/OppgaveIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/oppgave/OppgaveIT.kt
@@ -12,6 +12,7 @@ import no.nav.personbruker.dittnav.e2e.doknotifikasjon.DoknotifikasjonDTO
 import no.nav.personbruker.dittnav.e2e.operations.ApiOperations
 import no.nav.personbruker.dittnav.e2e.operations.ProducerOperations
 import no.nav.personbruker.dittnav.e2e.operations.VarselOperations
+import no.nav.personbruker.dittnav.e2e.security.BearerToken
 import no.nav.personbruker.dittnav.e2e.security.TokenInfo
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should contain all`
@@ -84,7 +85,7 @@ internal class OppgaveIT : UsesTheCommonDockerComposeContext() {
                 ServiceConfiguration.PRODUCER,
                 ProducerOperations.PRODUCE_OPPGAVE,
                 originalOppgave,
-                token
+                BearerToken(token.id_token)
             )
         }.status `should be equal to` HttpStatusCode.OK
     }
@@ -98,7 +99,7 @@ internal class OppgaveIT : UsesTheCommonDockerComposeContext() {
 
     private fun `get events`(token: TokenInfo, operation: ApiOperations): List<OppgaveDTO> {
         return runBlocking {
-            val response = client.get<List<OppgaveDTO>>(ServiceConfiguration.API, operation, token)
+            val response = client.get<List<OppgaveDTO>>(ServiceConfiguration.API, operation, BearerToken(token.id_token))
             response
         }
     }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/readiness/ReadinessIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/readiness/ReadinessIT.kt
@@ -40,7 +40,7 @@ internal class ReadinessIT : UsesTheCommonDockerComposeContext() {
         assertIsAliveForSingleService(ServiceConfiguration.TIDSLINJE, TidslinjeOperations.IS_ALIVE)
         assertIsAliveForSingleService(ServiceConfiguration.VARSELBESTILLER, VarselOperations.IS_ALIVE)
         assertIsAliveForSingleService(ServiceConfiguration.BRUKERNOTIFIKASJONBESTILLER, BNBOperations.IS_ALIVE)
-        assertIsAliveForSingleService(ServiceConfiguration.AUTH_MOCK, BNBOperations.IS_ALIVE)
+        assertIsAliveForSingleService(ServiceConfiguration.AUTH_MOCK, AuthMockOperations.IS_ALIVE)
     }
 
     @Test
@@ -54,8 +54,7 @@ internal class ReadinessIT : UsesTheCommonDockerComposeContext() {
         assertIsReadyForSingleService(ServiceConfiguration.TIDSLINJE, TidslinjeOperations.IS_READY)
         assertIsReadyForSingleService(ServiceConfiguration.VARSELBESTILLER, VarselOperations.IS_READY)
         assertIsReadyForSingleService(ServiceConfiguration.BRUKERNOTIFIKASJONBESTILLER, BNBOperations.IS_READY)
-        assertIsReadyForSingleService(ServiceConfiguration.AUTH_MOCK, BNBOperations.IS_READY)
-
+        assertIsReadyForSingleService(ServiceConfiguration.AUTH_MOCK, AuthMockOperations.IS_READY)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/tidslinje/TidslinjeIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/tidslinje/TidslinjeIT.kt
@@ -17,8 +17,10 @@ import no.nav.personbruker.dittnav.e2e.operations.ProducerOperations
 import no.nav.personbruker.dittnav.e2e.operations.ServiceOperation
 import no.nav.personbruker.dittnav.e2e.operations.TidslinjeOperations
 import no.nav.personbruker.dittnav.e2e.oppgave.ProduceOppgaveDTO
+import no.nav.personbruker.dittnav.e2e.security.BearerToken
 import no.nav.personbruker.dittnav.e2e.security.TokenInfo
 import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -26,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith
     ProducerContainerLogs::class,
     TidslinjeContainerLogs::class
 )
+@Disabled("Applikasjonen støtter ikke TokenX-tokens. Event-handler krever dette, og så lenge tidslinje-api ikke har denne støtten vil ikke denne testen fungere.")
 class TidslinjeIT : UsesTheCommonDockerComposeContext() {
 
     private val ident = "12345678901"
@@ -114,7 +117,7 @@ class TidslinjeIT : UsesTheCommonDockerComposeContext() {
 
     private fun `produce event at level`(originalEvent: BrukernotifikasjonDTO, operation: ServiceOperation, token: TokenInfo) {
         runBlocking {
-            httpClient.post<HttpResponse>(ServiceConfiguration.PRODUCER, operation, originalEvent, token)
+            httpClient.post<HttpResponse>(ServiceConfiguration.PRODUCER, operation, originalEvent, BearerToken(token.id_token))
         }.status `should be equal to` HttpStatusCode.OK
     }
 
@@ -126,10 +129,9 @@ class TidslinjeIT : UsesTheCommonDockerComposeContext() {
                     httpClient.get<List<Brukernotifikasjon>>(
                             ServiceConfiguration.TIDSLINJE,
                             operation,
-                            token,
+                            BearerToken(token.id_token),
                             parameters)
             response
         }
     }
-
 }


### PR DESCRIPTION
-Støtter tokenveksling for de appene som trenger det
-Nødvendige miljøvariabler tilpasset GCP-versjoner. 