### PR TITLE
Fjerne eventtidspunkt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -213,11 +213,9 @@ services:
       PERSONALIA_API_CLIENT_ID: "tms-personalia-api-client-id"
       TOKEN_X_CLIENT_ID: "dittnav-api-client-id"
       EVENTHANDLER_CLIENT_ID: "dittnav-event-handler-clientid"
-      MININNBOKS_API_URL: "http://mocks.dittnav.docker-internal:8080/mininnboks-api"
       MELDEKORT_API_URL: "http://mocks.dittnav.docker-internal:8080/meldekort-api"
       MELDEKORT_CLIENT_ID: "meldekort-client-id"
       OPPFOLGING_API_URL: "http://mocks.dittnav.docker-internal:8080/oppfolging"
-      INNLOGGINGSINFO_URL: "http://dummyInnloggingsinfo.nav.no"
     depends_on:
       oidc-provider:
         condition: service_started

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/beskjed/BeskjedDTO.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/beskjed/BeskjedDTO.kt
@@ -9,7 +9,6 @@ import java.time.ZonedDateTime
 
 @Serializable
 data class BeskjedDTO(
-        val eventTidspunkt: ZonedDateTime,
         val forstBehandlet: ZonedDateTime,
         val eventId: String,
         val tekst: String,

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/beskjed/BeskjedIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/beskjed/BeskjedIT.kt
@@ -90,8 +90,8 @@ internal class BeskjedIT : UsesTheCommonDockerComposeContext() {
         }
 
         val doknotifikasjonerToMatch = listOf(
-            DoknotifikasjonDTO("B-tms-event-test-producer-${activeBeskjed!![0].eventId}"),
-            DoknotifikasjonDTO("B-tms-event-test-producer-${activeBeskjed[1].eventId}")
+            DoknotifikasjonDTO(activeBeskjed!![0].eventId),
+            DoknotifikasjonDTO(activeBeskjed[1].eventId)
         )
 
         val doknotifikasjoner = `wait for values to be returned`(doknotifikasjonerToMatch) {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/done/DoneIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/done/DoneIT.kt
@@ -93,18 +93,18 @@ class DoneIT: UsesTheCommonDockerComposeContext() {
         `produser done-eventer for alle brukernotifikasjoner`(tokenAt4)
 
         val doknotifikasjonStoppForBeskjedToMatch = listOf(
-                DoknotifikasjonStoppDTO("B-tms-event-test-producer-${activeBeskjedEvents[0].eventId}"),
-                DoknotifikasjonStoppDTO("B-tms-event-test-producer-${activeBeskjedEvents[1].eventId}")
+                DoknotifikasjonStoppDTO(activeBeskjedEvents[0].eventId),
+                DoknotifikasjonStoppDTO(activeBeskjedEvents[1].eventId)
         )
 
         val doknotifikasjonStoppForOppgaveToMatch = listOf(
-                DoknotifikasjonStoppDTO("O-tms-event-test-producer-${activeOppgaveEvents[0].eventId}"),
-                DoknotifikasjonStoppDTO("O-tms-event-test-producer-${activeOppgaveEvents[1].eventId}")
+                DoknotifikasjonStoppDTO(activeOppgaveEvents[0].eventId),
+                DoknotifikasjonStoppDTO(activeOppgaveEvents[1].eventId)
         )
 
         val doknotifikasjonStoppForInnboksToMatch = listOf(
-                DoknotifikasjonStoppDTO("I-tms-event-test-producer-${activeInnboksEvents[0].eventId}"),
-                DoknotifikasjonStoppDTO("I-tms-event-test-producer-${activeInnboksEvents[1].eventId}")
+                DoknotifikasjonStoppDTO(activeInnboksEvents[0].eventId),
+                DoknotifikasjonStoppDTO(activeInnboksEvents[1].eventId)
         )
 
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/innboks/InnboksDTO.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/innboks/InnboksDTO.kt
@@ -8,7 +8,6 @@ import java.time.ZonedDateTime
 
 @Serializable
 data class InnboksDTO(
-        val eventTidspunkt: ZonedDateTime,
         val forstBehandlet: ZonedDateTime,
         val eventId: String,
         val tekst: String,

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/innboks/InnboksIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/innboks/InnboksIT.kt
@@ -66,8 +66,8 @@ class InnboksIT : UsesTheCommonDockerComposeContext() {
         }
 
         val doknotifikasjonerToMatch = listOf(
-                DoknotifikasjonDTO("I-tms-event-test-producer-${activeInnboks!![0].eventId}"),
-                DoknotifikasjonDTO("I-tms-event-test-producer-${activeInnboks[1].eventId}")
+                DoknotifikasjonDTO(activeInnboks!![0].eventId),
+                DoknotifikasjonDTO(activeInnboks[1].eventId)
         )
 
         val doknotifikasjoner = `wait for values to be returned`(doknotifikasjonerToMatch) {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/operations/FrontendOperations.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/operations/FrontendOperations.kt
@@ -3,6 +3,5 @@ package no.nav.personbruker.dittnav.e2e.operations
 enum class FrontendOperations(override val path: String) : ServiceOperation {
     IS_ALIVE("/internal/isAlive"),
     IS_READY("/internal/isAlive"),
-    SELFTEST("/internal/selftest"),
     METRICS("/internal/metrics")
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/oppgave/OppgaveDTO.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/oppgave/OppgaveDTO.kt
@@ -8,7 +8,6 @@ import java.time.ZonedDateTime
 
 @Serializable
 data class OppgaveDTO(
-        val eventTidspunkt: ZonedDateTime,
         val forstBehandlet: ZonedDateTime,
         val eventId: String,
         val tekst: String,

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/oppgave/OppgaveIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/oppgave/OppgaveIT.kt
@@ -68,8 +68,8 @@ internal class OppgaveIT : UsesTheCommonDockerComposeContext() {
         }
 
         val doknotifikasjonerToMatch = listOf(
-            DoknotifikasjonDTO("O-tms-event-test-producer-${activeOppgave!![0].eventId}"),
-            DoknotifikasjonDTO("O-tms-event-test-producer-${activeOppgave[1].eventId}")
+            DoknotifikasjonDTO(activeOppgave!![0].eventId),
+            DoknotifikasjonDTO(activeOppgave[1].eventId)
         )
 
         val doknotifikasjoner = `wait for values to be returned`(doknotifikasjonerToMatch) {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/e2e/readiness/ReadinessIT.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/e2e/readiness/ReadinessIT.kt
@@ -56,7 +56,6 @@ internal class ReadinessIT : UsesTheCommonDockerComposeContext() {
         assertSelftestForSingleService(ServiceConfiguration.API, ApiOperations.SELFTEST)
         assertSelftestForSingleService(ServiceConfiguration.HANDLER, HandlerOperations.SELFTEST)
         assertSelftestForSingleService(ServiceConfiguration.AGGREGATOR, AggregatorOperations.SELFTEST)
-        assertSelftestForSingleService(ServiceConfiguration.FRONTEND, FrontendOperations.SELFTEST)
         assertSelftestForSingleService(ServiceConfiguration.VARSELBESTILLER, VarselOperations.SELFTEST)
         assertSelftestForSingleService(ServiceConfiguration.BRUKERNOTIFIKASJONBESTILLER, BNBOperations.SELFTEST)
     }


### PR DESCRIPTION
Endret bestillingsid til å være == eventid. Sammen med https://github.com/navikt/pb-nav-mocked/pull/25 får dette e2e-testene grønne igjen.